### PR TITLE
Add radioheavy/captioneer to stores.json

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -1,4 +1,5 @@
 [
   "f/appetit",
-  "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json"
+  "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json",
+  "radioheavy/captioneer"
 ]


### PR DESCRIPTION
Adds `radioheavy/captioneer` to `stores.json` so WVW can ingest the root `apps.json` for Captioneer.