### PR TITLE
Add Shibutani Software Lab store

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -2,5 +2,6 @@
   "f/appetit",
   "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json",
   "stedwick/wvw.dev.apps",
-  "shametim/agent-chess"
+  "shametim/agent-chess",
+  "https://software-lab.shibukazu.com/apps.json"
 ]


### PR DESCRIPTION
Adds `https://software-lab.shibukazu.com/apps.json` to `stores.json` so WVW can ingest the Shibutani Software Lab store feed.