### PR TITLE
Add Mergen ADE store

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -1,6 +1,7 @@
 [
   "f/appetit",
   "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json",
+  "furkancak1r/mergen-ade",
   "stedwick/wvw.dev.apps",
   "shametim/agent-chess",
   "https://software-lab.shibukazu.com/apps.json",


### PR DESCRIPTION
## Summary
- add urkancak1r/mergen-ade to stores.json
- source manifest now lives at the repo root as pps.json on the default branch
- the listing targets the public GitHub Releases page for Mergen ADE's notarized macOS distribution

## Validation
- confirmed pps.json is present on urkancak1r/mergen-ade default branch
- confirmed the source repo currently publishes macOS DMG releases via GitHub Releases
