### PR TITLE
Add QuadCode — multi-agent AI terminal for macOS

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -1,7 +1,8 @@
 [
-  "f/appetit",
-  "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json",
-  "stedwick/wvw.dev.apps",
-  "shametim/agent-chess",
-  "https://software-lab.shibukazu.com/apps.json"
+    "f/appetit",
+    "https://raw.githubusercontent.com/f/catalog/main/wvw.apps.json",
+    "stedwick/wvw.dev.apps",
+    "shametim/agent-chess",
+    "https://software-lab.shibukazu.com/apps.json",
+    "fixittech-sales/quadcode-listing"
 ]


### PR DESCRIPTION
Adding [QuadCode](https://getquadcode.com) to the World Vibe Web catalog.

QuadCode is a native macOS app that lets developers run Claude, Gemini, Codex, and Aider side by side in split panes. Broadcast commands, compare agent outputs, Auto Bypass Mode for hands-free runs.

- Store: fixittech-sales/quadcode-listing
- App URL: https://getquadcode.com
- Categories: macos, developer-tools