### PR TITLE
App Review Submission: Third Time’s the Charm

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -6,9 +6,6 @@
   "shametim/agent-chess",
   "https://software-lab.shibukazu.com/apps.json",
   "fixittech-sales/quadcode-listing",
-  "radioheavy/wiro_cl-",
-  "radioheavy/captioneer",
-  "radioheavy/avalon",
-  "radioheavy/wiro-extension",
+  "radioheavy/radioheavy-apps",
   "kagantemizkan/MyStore"
 ]


### PR DESCRIPTION
Hello World Vibe Web Review Team,

We are back for what is now clearly a multi-part educational series on how a distributed app store works.

This PR replaces the previous four separate Radioheavy store entries with a single unified store:

- `radioheavy/radioheavy-apps`

That store now contains:
- `Captioneer`
- `Avalon`
- `Wiro CLI`
- `Wiro Models Cleaner`

## What Changed

After exploring several exciting but ultimately character-building interpretations of the spec, this submission now follows the intended model:

- one repo
- one `apps.json`
- multiple apps
- one store entry in `stores.json`

In other words: no bundled feed living in the wrong repo, no four separate stores each holding exactly one app like tiny anxious kiosks, and no further attempts to freestyle the distributed-store doctrine.

## Review Notes

This build has been tested for:
- correct understanding of “one store can contain multiple apps”
- significantly reduced reviewer déjà vu
- improved repo boundaries
- restored architectural dignity

Thank you for your patience through the earlier seasons of this submission.

Respectfully resubmitted for Review Round 3,  
now with 75% less accidental lore