### PR TITLE
Add Jubstaaa/appetit store

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -7,5 +7,6 @@
   "https://software-lab.shibukazu.com/apps.json",
   "fixittech-sales/quadcode-listing",
   "radioheavy/radioheavy-apps",
-  "kagantemizkan/MyStore"
+  "kagantemizkan/MyStore",
+  "Jubstaaa/appetit"
 ]


### PR DESCRIPTION
## Summary
- Adds `Jubstaaa/appetit` to `stores.json`
- Store contains 3 apps:
  - **Pixel Guess** — Web-based pixel guessing game with 12 language support
  - **Pixel Guess Mobile** — iOS app available on the App Store
  - **Hono Telescope** — Open-source monitoring dashboard for Hono apps (npm package)

## Store Repository
https://github.com/Jubstaaa/appetit