### PR TITLE
Add GitHub Repo Manager & Cleaner AI to stores

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -24,5 +24,6 @@
   "akeslo/wvw.com",
   "yusufaltunbicak/outlook-cli",
   "mergisi/apps",
-  "apo-bozdag/SoundShift"
+  "apo-bozdag/SoundShift",
+  "palamut62/github-repo-cleaner-ai"
 ]


### PR DESCRIPTION
## Summary
- Adds `palamut62/github-repo-cleaner-ai` to `stores.json`
- An Electron desktop app for managing, cleaning, and organizing GitHub repositories with AI-powered features (smart rename, README generation, commit analysis)
- `apps.json` is already set up in the source repo with valid categories and schema

## App Details
- **Name:** GitHub Repo Manager & Cleaner
- **Categories:** developer-tools, utilities, productivity
- **Platform:** Desktop (Electron)
- **Price:** Free
- **Homepage:** https://github-repo-cleaner-aiwebpage.vercel.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)