### PR TITLE
chore(stores): add Cryplink to the list of app sources

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -27,5 +27,6 @@
   "apo-bozdag/SoundShift",
   "palamut62/github-repo-cleaner-ai",
   "https://seodisias.com/apps.json",
-  "https://node-pad.com/app.json"
+  "https://node-pad.com/app.json",
+  "https://cryplink.io/apps.json"
 ]


### PR DESCRIPTION
PR opened to add Cryplink to the marketplace.

Cryplink allows creators to sell digital products with crypto by simply uploading a product and sharing a link.