### PR TITLE
Add Wallnetic - Live Video Wallpaper Engine for macOS

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -31,5 +31,6 @@
   "osman-koc/my-apps",
   "efekurucay/terminal-alias-manager",
   "https://cryplink.io/apps.json",
-  "basarozcan/gitlab-in-menubar"
+  "basarozcan/gitlab-in-menubar",
+  "fatihkan/wallnetic"
 ]


### PR DESCRIPTION
## Adding Wallnetic

**Repository:** https://github.com/fatihkan/wallnetic
**apps.json:** https://github.com/fatihkan/wallnetic/blob/main/apps.json

### About Wallnetic

Live Video Wallpaper Engine for macOS - like Wallpaper Engine for Windows, but native for Mac.

### Features

- 🎬 Live video wallpapers (MP4, MOV, M4V)
- 🖥️ Multi-monitor support
- 📁 Library with collections & favorites
- ⚡ Metal GPU acceleration
- 🔋 Smart power management
- 🌙 Dark/Light/System themes
- 🚀 Launch at login

### Details

| Field | Value |
|-------|-------|
| Platform | macOS 13.0+ |
| Price | Free |
| Category | Graphics & Design |
| Architecture | Apple Silicon + Intel |

### Links

- GitHub: https://github.com/fatihkan/wallnetic
- Release: https://github.com/fatihkan/wallnetic/releases/tag/v1.0.0
- Author: [@KanFatih](https://twitter.com/KanFatih)