### PR TITLE
Add CreedFlow — AI orchestration platform for macOS

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -32,5 +32,6 @@
   "efekurucay/terminal-alias-manager",
   "https://cryplink.io/apps.json",
   "basarozcan/gitlab-in-menubar",
-  "fatihkan/wallnetic"
+  "fatihkan/wallnetic",
+  "fatihkan/creedflow"
 ]


### PR DESCRIPTION
Adds [CreedFlow](https://github.com/fatihkan/creedflow) to the wvw.dev directory.

**CreedFlow** is a macOS-native AI orchestration platform that autonomously manages software projects — task decomposition, multi-backend AI routing (Claude, Codex, Gemini + local LLMs), automated code review, and deployment from a native SwiftUI app.

- `apps.json`: https://github.com/fatihkan/creedflow/blob/main/apps.json
- Icon: https://raw.githubusercontent.com/fatihkan/creedflow/main/docs/assets/icon.png