### PR TITLE
Add FindUtils store - 302 free online tools

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -33,5 +33,6 @@
   "https://cryplink.io/apps.json",
   "basarozcan/gitlab-in-menubar",
   "fatihkan/wallnetic",
-  "hakancelikdev/vakit"
+  "hakancelikdev/vakit",
+  "https://findutils.com/apps.json"
 ]


### PR DESCRIPTION
## Summary

- Adds `https://findutils.com/apps.json` to `stores.json`
- **302 free web-based tools** across 7 categories:
  - Developer Tools (JSON formatters, regex tester, code generators, API tools)
  - Utilities (unit converters, image compressors, video tools, text tools)
  - Productivity (PDF editor, timers, spreadsheet editor, slide builder)
  - Finance (loan calculators, invoice generator, ROI calculator)
  - Education (GPA calculator, flashcard maker, quiz maker)
  - Graphics & Design (photo editor, color tools, gradient generator)
  - Web (all tools run in-browser, no server processing)
- All tools are free, client-side, and open - no login required
- Each app has an OG image icon
- Store URL: https://findutils.com/apps.json
- GitHub: https://github.com/olgunozoktas/findutils-tools