### PR TITLE
Add Portier — macOS menu bar port monitor

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -38,5 +38,6 @@
   "emrahyurttutan/my-apps",
   "olgunozoktas/findutils-tools",
   "abutun/appetit",
-  "erdalbektas/VaxOnVaxOff"
+  "erdalbektas/VaxOnVaxOff",
+  "mesto-ai/portier"
 ]


### PR DESCRIPTION
Adding **Portier** by [mesto.ai](https://github.com/mesto-ai) to the WVW store.

**Portier** is a macOS menu bar app that monitors active network ports and processes in real-time.

- Real-time monitoring with auto-refresh
- Smart process categorization (Development, Apps, Browsers, Infrastructure, System)
- Process management directly from menu bar
- Search & filter
- Turkish & English support
- Dark mode

Repository: https://github.com/mesto-ai/portier