### PR TITLE
Add CloakNote store

### DIFF
--- a/stores.json
+++ b/stores.json
@@ -40,5 +40,6 @@
   "abutun/appetit",
   "erdalbektas/VaxOnVaxOff",
   "mesto-ai/portier",
+  "sarisen/CloakNote",
   "fatihsolhan/prompts-chat-extension"
 ]


### PR DESCRIPTION
Adds sarisen/CloakNote to stores.json so WVW can ingest its root apps.json.\n\nStore repo: https://github.com/sarisen/CloakNote